### PR TITLE
ensure requirements.txt file is shipped in the sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Compiled python modules.
 *.pyc
 
-# Manifest
-MANIFEST.in
-
 # build distribution folder.
 /build/
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include *.txt
+include README.md
+
+graft pyxpcm
+
+prune *.egg-info
+
+exclude *.yml
+exclude .gitignore


### PR DESCRIPTION
The Source distribution is not installable without this file. I had to remove the MANIFEST.in from the .gitignore file to fix this.


BTW, I can convert the whole thing to a modern pyproject.toml in another PR. Just wanted to do a PR that fixes the problem but doesn't modify the current workflow too much. 